### PR TITLE
[TASK] Update php constraint to support ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description" : "Simple but powerful configuration handling for TYPO3 CMS",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.0 <7.4",
+        "php": "^7.0",
         "ext-json": "*",
         "typo3/cms-core": "^7.6 || ^8.7",
         "helhum/config-loader": ">=0.9 <0.13",


### PR DESCRIPTION
With this change the limitation of the PHP version 7.0 < 7.4 is changed
to support PHP >= 7.0 and with this allows e.g. 7.4.