### PR TITLE
[BUGFIX] Correctly expose user only config

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -97,3 +97,9 @@ jobs:
                 run: |
                     rm -rf var/cache/*
                     vendor/bin/typo3cms site:list | grep my-fancy-host
+
+            -   name: BE Config Test
+                if: ${{ matrix.typo3 != '^9.5.0' }}
+                run: |
+                    rm -rf var/cache/*
+                    vendor/bin/typo3cms configuration:showlocal BE/explicitADmode --json | grep explicitAllow

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -83,5 +83,5 @@ return PhpCsFixer\Config::create()
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->exclude('vendor')
-            ->exclude('.Build')
+            ->exclude('public')
     );

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -65,3 +65,4 @@ finder:
     - "*.php"
   exclude:
     - "vendor"
+    - "public"

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -24,6 +24,7 @@ namespace Helhum\TYPO3\ConfigHandling;
 
 use Helhum\ConfigLoader\CachedConfigurationLoader;
 use Helhum\ConfigLoader\ConfigurationLoader;
+use Helhum\ConfigLoader\InvalidConfigurationFileException;
 use Helhum\ConfigLoader\Processor\PlaceholderValue;
 use Helhum\TYPO3\ConfigHandling\Processor\ExtensionSettingsSerializer;
 use Helhum\Typo3Console\Mvc\Cli\Symfony\Input\ArgvInput;
@@ -87,14 +88,46 @@ EOF;
         return $shouldCache && preg_match($lowLevelNamespaces, $input->getFirstArgument() ?? 'list') === 0;
     }
 
+    /**
+     * Complete config
+     * Cached in production
+     *
+     * @throws InvalidConfigurationFileException
+     * @return array
+     */
     public function load(): array
     {
         return $this->buildLoader()->load();
     }
 
+    /**
+     * Complete config, but without overrides config
+     *
+     * @return array
+     */
     public function loadBase(): array
     {
         return (new Typo3Config($this->settingsFile))->readBaseConfig();
+    }
+
+    /**
+     * Config with overrides file, but without TYPO3 defaults
+     *
+     * @return array
+     */
+    public function loadOwn(): array
+    {
+        return (new Typo3Config($this->settingsFile))->readOwnConfig();
+    }
+
+    /**
+     * Config from overrides file
+     *
+     * @return array
+     */
+    public function loadOverrides(): array
+    {
+        return (new Typo3Config($this->settingsFile))->readOverridesConfig();
     }
 
     public function flushCache(): void

--- a/tests/Unit/ConfigLoaderTest.php
+++ b/tests/Unit/ConfigLoaderTest.php
@@ -22,7 +22,6 @@ namespace Helhum\TYPO3\ConfigHandling\Tests\Unit;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use Composer\InstalledVersions;
 use Helhum\TYPO3\ConfigHandling\ConfigLoader;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
ConfigurationManager::getLocalConfiguration must return
user config only, but until now returned full config
cleaned from default values, which mostly is the same thing,
but not in all cases.

Therefore API is introduced to really only return
user config values instead.

Fixes: #26