### PR TITLE
Delete cache after updating the configuration in backend

### DIFF
--- a/src/Xclass/ConfigurationManager.php
+++ b/src/Xclass/ConfigurationManager.php
@@ -289,6 +289,7 @@ class ConfigurationManager
         );
         if (!empty($remainingConfigToWrite)) {
             $this->configDumper->dumpToFile(array_replace_recursive($this->configLoader->loadOverrides(), $remainingConfigToWrite), $overrideSettingsFile);
+            $this->configLoader->flushCache();
         }
     }
 


### PR DESCRIPTION
Cached config file is not cleared in Production mode because cache isn't cleared