### PR TITLE
!!! Configured processors now need a key for identifcation

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [ push, pull_request ]
+on:
+    push:
+        branches:
+            - main
+            - /^v?([0-9]+\.){1,2}(x|[0-9]+)-?[a-z]*[1-9]*$/
+    pull_request:
+        branches:
+            - main
 
 jobs:
 
@@ -11,39 +18,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                typo3: [ '^9.5.0', '^10.4.0', '^11.5.0' ]
-                php: [ '7.4' ]
+                typo3: [ '^11.5.0' ]
+                php: [ '7.4', '8.0', '8.1', 'nightly' ]
                 dependency-version: [ lowest, stable ]
                 experimental: [ false ]
-                include:
-                    -   php: 7.2
-                        typo3: '^9.5.0'
-                        dependency-version: stable
-                        experimental: false
-                    -   php: 7.3
-                        typo3: '^9.5.0'
-                        dependency-version: stable
-                        experimental: false
-                    -   php: 7.2
-                        typo3: '^10.4.0'
-                        dependency-version: stable
-                        experimental: false
-                    -   php: 7.3
-                        typo3: '^10.4.0'
-                        dependency-version: stable
-                        experimental: false
-                    -   php: 8.0
-                        typo3: '^11.5.0'
-                        dependency-version: stable
-                        experimental: false
-                    -   php: 8.1
-                        typo3: '^11.5.0'
-                        dependency-version: stable
-                        experimental: false
-                    -   php: nightly
-                        typo3: '^11.5.0'
-                        dependency-version: stable
-                        experimental: true
 
         continue-on-error: ${{ matrix.experimental }}
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ There are some prerequisites to follow if you want to use this feature:
 
   ```yaml
   processors:
-     - class: Helhum\TYPO3\ConfigHandling\Processor\DecryptSettingsProcessor
+      decrypt:
+          class: Helhum\TYPO3\ConfigHandling\Processor\DecryptSettingsProcessor
   ```
 
 As you can see, the decryption is solely based on a processor, which handles the

--- a/composer.json
+++ b/composer.json
@@ -3,22 +3,22 @@
     "description" : "Simple but powerful configuration handling for TYPO3 CMS",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-json": "*",
         "helhum/config-loader": ">=0.12.4 <0.13",
-        "helhum/typo3-console": "^5.7 || ^6.0 || ^7.0",
-        "symfony/console": "^4.0 || ^5.0",
-        "symfony/yaml": "^4.0 || ^5.0",
-        "typo3/cms-composer-installers": "^2.0 || ^3.0 || ^4.0",
-        "typo3/cms-core": "^9.5.31 || ^10.4.21 || ^11.5.1",
-        "composer-runtime-api": "^2.1",
+        "helhum/typo3-console": "^7.0",
+        "symfony/console": "^5.4",
+        "symfony/yaml": "^5.4",
+        "typo3/cms-composer-installers": "^3.0 || ^4.0",
+        "typo3/cms-core": "^11.5.1",
+        "composer-runtime-api": "^2.2",
         "symfony/polyfill-php80": "^1.23.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "composer/composer": "^2.1",
+        "composer/composer": "^2.2",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6.10"
     },
     "conflict": {
         "typo3-console/composer-auto-commands": "< 0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "helhum/typo3-config-handling",
     "description" : "Simple but powerful configuration handling for TYPO3 CMS",
     "license": "GPL-2.0-or-later",
+    "config": {
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
+    },
     "require": {
         "php": ">=7.4",
         "ext-json": "*",

--- a/src/Xclass/ConfigurationManager.php
+++ b/src/Xclass/ConfigurationManager.php
@@ -127,7 +127,6 @@ class ConfigurationManager
      * @var array
      */
     protected $whiteListedLocalConfigurationPaths = [
-        'EXT/extConf',
         'EXTCONF',
         'DB',
         'SYS/caching/cacheConfigurations',
@@ -371,6 +370,9 @@ class ConfigurationManager
 
     /**
      * Update a given path in local configuration to a new value.
+     * Warning: TO BE USED ONLY to update a single feature.
+     * NOT TO BE USED within iterations to update multiple features.
+     * To update multiple features use setLocalConfigurationValuesByPathValuePairs().
      *
      * @param string $path Path to update
      * @param mixed $value Value to set
@@ -431,6 +433,9 @@ class ConfigurationManager
     /**
      * Enables a certain feature and writes the option to LocalConfiguration.php
      * Short-hand method
+     * Warning: TO BE USED ONLY to enable a single feature.
+     * NOT TO BE USED within iterations to enable multiple features.
+     * To update multiple features use setLocalConfigurationValuesByPathValuePairs().
      *
      * @param string $featureName something like "InlineSvgImages"
      * @return bool true on successful writing the setting
@@ -443,6 +448,9 @@ class ConfigurationManager
     /**
      * Disables a feature and writes the option to LocalConfiguration.php
      * Short-hand method
+     * Warning: TO BE USED ONLY to disable a single feature.
+     * NOT TO BE USED within iterations to disable multiple features.
+     * To update multiple features use setLocalConfigurationValuesByPathValuePairs().
      *
      * @param string $featureName something like "InlineSvgImages"
      * @return bool true on successful writing the setting


### PR DESCRIPTION
Instead of being an array, processors must now
be defined as a map, so that every processor can
be identified with a key.

This allows easier overriding of already defined processors
and makes the code for removing options with a processor
much simpler.

Closes #34