### PR TITLE
 [BUGFIX] Fix cache flush if caching is enabled via `TYPO3_CONFIG_HANDLING_CACHE`

### DIFF
--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -132,7 +132,7 @@ EOF;
 
     public function flushCache(): void
     {
-        if (!$this->isProduction) {
+        if (!$this->shouldCache()) {
             return;
         }
         $cacheFilePattern = str_replace($this->getCacheIdentifier(), '*', $this->getCacheFile());


### PR DESCRIPTION
(cherry picked from commit 8271f25da0d1486ca90ad497ed925b950b883a1d)