### PR TITLE
[TASK] Only read override settings file if it has config

### DIFF
--- a/src/Install/Action/SetupConfigurationAction.php
+++ b/src/Install/Action/SetupConfigurationAction.php
@@ -125,7 +125,8 @@ class SetupConfigurationAction implements InstallActionInterface
     private function addValuesToOverrides(array $values): void
     {
         $configFile = SettingsFiles::getOverrideSettingsFile();
-        $currentConfig = (new ConfigurationReaderFactory(dirname($configFile)))->createReader($configFile)->readConfig();
+        $reader = (new ConfigurationReaderFactory(dirname($configFile)))->createReader($configFile);
+        $currentConfig = $reader->hasConfig() ? $reader->readConfig() : [];
         $this->configDumper->dumpToFile(array_replace_recursive($currentConfig, $values), $configFile);
     }
 

--- a/src/Install/Action/SetupConfigurationAction.php
+++ b/src/Install/Action/SetupConfigurationAction.php
@@ -90,10 +90,6 @@ class SetupConfigurationAction implements InstallActionInterface
             $customConfig = Config::setValue($customConfig, $argumentDefinitions[$argumentName]['configPath'], $argumentValue);
         }
 
-//        if (empty($customConfig)) {
-//            return;
-//        }
-
         $this->addValuesToOverrides($customConfig);
     }
 

--- a/src/Install/Action/SetupConfigurationAction.php
+++ b/src/Install/Action/SetupConfigurationAction.php
@@ -89,6 +89,9 @@ class SetupConfigurationAction implements InstallActionInterface
         foreach ($arguments as $argumentName => $argumentValue) {
             $customConfig = Config::setValue($customConfig, $argumentDefinitions[$argumentName]['configPath'], $argumentValue);
         }
+        if ($customConfig === []) {
+            return;
+        }
         $this->addValuesToOverrides($customConfig);
     }
 
@@ -127,13 +130,10 @@ class SetupConfigurationAction implements InstallActionInterface
         $configFile = SettingsFiles::getOverrideSettingsFile();
         $reader = (new ConfigurationReaderFactory(dirname($configFile)))->createReader($configFile);
         $currentConfig = $reader->hasConfig() ? $reader->readConfig() : [];
-        $config = array_replace_recursive($currentConfig, $values);
-
-        if(empty($config)) {
-            return;
-        }
-
-        $this->configDumper->dumpToFile($config, $configFile);
+        $this->configDumper->dumpToFile(
+            array_replace_recursive($currentConfig, $values),
+            $configFile
+        );
     }
 
     private function copyEnvDistFile(): void

--- a/src/Install/Action/SetupConfigurationAction.php
+++ b/src/Install/Action/SetupConfigurationAction.php
@@ -89,7 +89,6 @@ class SetupConfigurationAction implements InstallActionInterface
         foreach ($arguments as $argumentName => $argumentValue) {
             $customConfig = Config::setValue($customConfig, $argumentDefinitions[$argumentName]['configPath'], $argumentValue);
         }
-
         $this->addValuesToOverrides($customConfig);
     }
 

--- a/src/Install/Action/SetupConfigurationAction.php
+++ b/src/Install/Action/SetupConfigurationAction.php
@@ -89,6 +89,11 @@ class SetupConfigurationAction implements InstallActionInterface
         foreach ($arguments as $argumentName => $argumentValue) {
             $customConfig = Config::setValue($customConfig, $argumentDefinitions[$argumentName]['configPath'], $argumentValue);
         }
+
+//        if (empty($customConfig)) {
+//            return;
+//        }
+
         $this->addValuesToOverrides($customConfig);
     }
 
@@ -127,7 +132,13 @@ class SetupConfigurationAction implements InstallActionInterface
         $configFile = SettingsFiles::getOverrideSettingsFile();
         $reader = (new ConfigurationReaderFactory(dirname($configFile)))->createReader($configFile);
         $currentConfig = $reader->hasConfig() ? $reader->readConfig() : [];
-        $this->configDumper->dumpToFile(array_replace_recursive($currentConfig, $values), $configFile);
+        $config = array_replace_recursive($currentConfig, $values);
+
+        if(empty($config)) {
+            return;
+        }
+
+        $this->configDumper->dumpToFile($config, $configFile);
     }
 
     private function copyEnvDistFile(): void


### PR DESCRIPTION
In our setup we don't use the `defaultConfiguration` step but use the use the `SetupConfigurationAction` to set `customOverrideSettings`.

Because of the missing `defaultConfiguration` step the `override.settings.yaml` was not created before the `SetupConfigurationAction` got executed. In this case `readConfig()` throws an error that the file does not exist.

Therefore we have to check if the file has config before reading it.