### PR TITLE
[BUGFIX] Fix PHP 8.3 deprecation for implicit nullable arguments

### DIFF
--- a/src/Xclass/ConfigurationManager.php
+++ b/src/Xclass/ConfigurationManager.php
@@ -139,9 +139,9 @@ class ConfigurationManager
     ];
 
     public function __construct(
-        ConfigLoader $configLoader = null,
-        ConfigDumper $configDumper = null,
-        ConfigCleaner $configCleaner = null
+        ?ConfigLoader $configLoader = null,
+        ?ConfigDumper $configDumper = null,
+        ?ConfigCleaner $configCleaner = null
     ) {
         $this->configLoader = $configLoader ?: new ConfigLoader(Environment::getContext()->isProduction());
         $this->configDumper = $configDumper ?: new ConfigDumper();


### PR DESCRIPTION
```
Deprecated: Helhum\TYPO3\ConfigHandling\Xclass\ConfigurationManager::__construct(): Implicitly marking parameter $configLoader as nullable is deprecated, the explicit nullable type must be used instead in /Users/moritzngo/Projects/kandoh/customers/gwj/mulco-typo3-website/vendor/helhum/typo3-config-handling/src/Xclass/ConfigurationManager.php on line 141
Deprecated: Helhum\TYPO3\ConfigHandling\Xclass\ConfigurationManager::__construct(): Implicitly marking parameter $configDumper as nullable is deprecated, the explicit nullable type must be used instead in /Users/moritzngo/Projects/kandoh/customers/gwj/mulco-typo3-website/vendor/helhum/typo3-config-handling/src/Xclass/ConfigurationManager.php on line 141
Deprecated: Helhum\TYPO3\ConfigHandling\Xclass\ConfigurationManager::__construct(): Implicitly marking parameter $configCleaner as nullable is deprecated, the explicit nullable type must be used instead in /Users/moritzngo/Projects/kandoh/customers/gwj/mulco-typo3-website/vendor/helhum/typo3-config-handling/src/Xclass/ConfigurationManager.php on line 141
```