### PR TITLE
[FEATURE] Allow disabling config handling by env var

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -84,6 +84,11 @@ jobs:
                     rm -rf var/cache/*
                     vendor/bin/typo3 site:list | grep my-fancy-host
 
+            -   name: Disabled test
+                env:
+                    TYPO3_TESTING: '1'
+                run: vendor/bin/typo3 configuration:showactive SYS/sitename | grep -v 'Console site' | grep TYPO3
+
             -   name: BE Config Test
                 run: |
                     rm -rf var/cache/*

--- a/res/php/autoload-include.php
+++ b/res/php/autoload-include.php
@@ -1,2 +1,4 @@
 <?php
-class_alias(\Helhum\TYPO3\ConfigHandling\Xclass\ConfigurationManager::class, \TYPO3\CMS\Core\Configuration\ConfigurationManager::class);
+if (!isset($_ENV['TYPO3_TESTING']) && getenv('TYPO3_TESTING') === false) {
+    class_alias(\Helhum\TYPO3\ConfigHandling\Xclass\ConfigurationManager::class, \TYPO3\CMS\Core\Configuration\ConfigurationManager::class);
+}


### PR DESCRIPTION
To allow testing in non composer testing framework mode the 
`class_alias` is now skipped when TYPO3_TESTING env var is set