### PR TITLE
[TASK] Avoid implicitly nullable class method parameter

### DIFF
--- a/src/Command/ExtractSettingsCommand.php
+++ b/src/Command/ExtractSettingsCommand.php
@@ -47,8 +47,8 @@ class ExtractSettingsCommand extends Command
 
     public function __construct(
         $name = null,
-        ConfigurationManager $configurationManager = null,
-        ConfigExtractor $configExtractor = null
+        ?ConfigurationManager $configurationManager = null,
+        ?ConfigExtractor $configExtractor = null
     ) {
         parent::__construct($name);
         $this->configurationManager = $configurationManager ?: new ConfigurationManager();

--- a/src/ConfigDumper.php
+++ b/src/ConfigDumper.php
@@ -172,7 +172,7 @@ EOF;
         return addcslashes($value, '\\\'');
     }
 
-    private function extractPlaceHolder($value, array $types = null): array
+    private function extractPlaceHolder($value, ?array $types = null): array
     {
         if (!$this->isPlaceHolder($value)) {
             return [];

--- a/src/ConfigExtractor.php
+++ b/src/ConfigExtractor.php
@@ -53,11 +53,11 @@ class ConfigExtractor
     private $overrideConfigFile;
 
     public function __construct(
-        ConfigDumper $configDumper = null,
-        ConfigCleaner $configCleaner = null,
-        ConfigLoader $configLoader = null,
-        ConfigurationReaderFactory $readerFactory = null,
-        string $overrideConfigFile = null
+        ?ConfigDumper $configDumper = null,
+        ?ConfigCleaner $configCleaner = null,
+        ?ConfigLoader $configLoader = null,
+        ?ConfigurationReaderFactory $readerFactory = null,
+        ?string $overrideConfigFile = null
     ) {
         $this->configDumper = $configDumper ?: new ConfigDumper();
         $this->configCleaner = $configCleaner ?: new ConfigCleaner();
@@ -66,7 +66,7 @@ class ConfigExtractor
         $this->overrideConfigFile = $overrideConfigFile ?: SettingsFiles::getOverrideSettingsFile();
     }
 
-    public function extractConfig(array $config, array $defaultConfig, string $configFile = null): bool
+    public function extractConfig(array $config, array $defaultConfig, ?string $configFile = null): bool
     {
         $configFile = $configFile ?: $this->overrideConfigFile;
         $extractedConfig = false;

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -44,7 +44,7 @@ class ConfigLoader
      */
     private $settingsFile;
 
-    public function __construct(bool $isProduction, string $settingsFile = null)
+    public function __construct(bool $isProduction, ?string $settingsFile = null)
     {
         $this->isProduction = $isProduction;
         $this->settingsFile = $settingsFile ?? SettingsFiles::getSettingsFile($this->isProduction);

--- a/src/ConfigReader/ArrayReader.php
+++ b/src/ConfigReader/ArrayReader.php
@@ -38,7 +38,7 @@ class ArrayReader implements ConfigReaderInterface
      */
     private $configPath;
 
-    public function __construct(array $config, string $configPath = null)
+    public function __construct(array $config, ?string $configPath = null)
     {
         $this->config = $config;
         $this->configPath = $configPath;

--- a/src/Install/Action/FixupSiteConfigAction.php
+++ b/src/Install/Action/FixupSiteConfigAction.php
@@ -34,7 +34,7 @@ class FixupSiteConfigAction implements InstallActionInterface
         $this->output = $output;
     }
 
-    public function setCommandDispatcher(CommandDispatcher $commandDispatcher = null)
+    public function setCommandDispatcher(?CommandDispatcher $commandDispatcher = null)
     {
         $this->commandDispatcher = $commandDispatcher;
     }

--- a/src/Install/Action/SetupConfigurationAction.php
+++ b/src/Install/Action/SetupConfigurationAction.php
@@ -48,7 +48,7 @@ class SetupConfigurationAction implements InstallActionInterface
      */
     private $commandDispatcher;
 
-    public function __construct(ConfigDumper $configDumper = null)
+    public function __construct(?ConfigDumper $configDumper = null)
     {
         $this->configDumper = $configDumper ?? new ConfigDumper();
     }
@@ -58,7 +58,7 @@ class SetupConfigurationAction implements InstallActionInterface
         $this->output = $output;
     }
 
-    public function setCommandDispatcher(CommandDispatcher $commandDispatcher = null): void
+    public function setCommandDispatcher(?CommandDispatcher $commandDispatcher = null): void
     {
         $this->commandDispatcher = $commandDispatcher;
     }

--- a/src/Typo3Config.php
+++ b/src/Typo3Config.php
@@ -54,7 +54,7 @@ class Typo3Config implements ConfigReaderInterface
      */
     private $overridesReader;
 
-    public function __construct(string $configFile, ConfigurationReaderFactory $readerFactory = null)
+    public function __construct(string $configFile, ?ConfigurationReaderFactory $readerFactory = null)
     {
         $readerFactory = $readerFactory ?? new ConfigurationReaderFactory(dirname($configFile));
         $readerFactory->setReaderFactoryForType(


### PR DESCRIPTION
This change is a part of PR #61, but is smaller in scope as it only deals with the deprecation of implicitly nullable parameters, which hopefully makes it easier to merge.

Changes were done using the php-cs-fixer command: 

`php-cs-fixer fix --rules=nullable_type_declaration,nullable_type_declaration_for_default_null_value`