### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
         "typo3/cms-composer-installers": "^4.0@rc || >=5.0",
         "typo3/cms-core": "^12.4 || ^13.4",
-        "composer-runtime-api": "^2.2",
-        "symfony/polyfill-php80": "^1.23.1"
+        "composer-runtime-api": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.36",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: >=8.1`, so the polyfill requirement doesn't seem necessary anymore?